### PR TITLE
Fix Debian source package name

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-opx-sdi-sys (1.0.1) main; urgency=medium
+opx-sdi-sys-vm (1.0.1) main; urgency=medium
 
   * Initial release
 

--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: opx-sdi-sys
+Source: opx-sdi-sys-vm
 Section: net
 Priority: optional
 Maintainer: Dell <support@dell.com>


### PR DESCRIPTION
Update source package name in debian/control and debian/changelog.  This
was using the same name as opx-sdi-sys, resulting in the same file names
being used for some of the build output.